### PR TITLE
Collect dataset size per engine

### DIFF
--- a/mysql/sql/README.md
+++ b/mysql/sql/README.md
@@ -1,0 +1,35 @@
+# collect_dataset_size_per_engine.sql
+
+This batch script is used to get logical dataset size per MySQL engine.
+
+## Why?
+
+The provides an overview of what database engine(s) is primarily used. You can use information as one of the factors on whether the current MySQL and OS configuration are still optimal for this system.
+
+## Usage
+
+Contents of the script can be run in batch mode or copied and pasted to MySQL console.
+
+### Example
+
+````
+$ mysql -u root < collect_dataset_size_per_engine.sql
+````
+
+In the output below, the number of tables, rows, data size, index size and its ratio are shown. 
+````
+mysql: [Warning] Using a password on the command line interface can be insecure.
+engine	tables	rows	data	idx	total_size	idxfrac
+InnoDB	49	48.61M	10.81G	0.29G	11.10G	0.03
+MyISAM	10	0.00M	0.00G	0.00G	0.00G	0.14
+MEMORY	63	NULL	0.00G	0.00G	0.00G	NULL
+CSV	2	0.00M	0.00G	0.00G	0.00G	NULL
+PERFORMANCE_SCHEMA	87	1.43M	0.00G	0.00G	0.00G	NULL
+NULL	100	NULL	NULL	NULL	NULL	NULL
+````
+
+With this information, you can infer that MySQL server uses InnoDB, 49 InnoDB tables, and around 11G of dataset.
+
+## Caution 
+
+Huge number of tables can slowness in performing this script and can impact server performance. Aside from setting innodb_stats_on_metadata to 0, it's best to run this during off peak hours.

--- a/mysql/sql/collect_dataset_size_per_engine.sql
+++ b/mysql/sql/collect_dataset_size_per_engine.sql
@@ -1,0 +1,15 @@
+-- Get dataset size per storage engine in MySQL
+
+SET @current_innodb_stats_on_metadata = @@global.innodb_stats_on_metadata;
+SET @@global.innodb_stats_on_metadata = 0;
+SELECT engine,
+  COUNT(*) tables,
+  CONCAT(ROUND(SUM(table_rows)/1000000,2),'M') rows,
+  CONCAT(ROUND(SUM(data_length)/(1024*1024*1024),2),'G') data,
+  CONCAT(ROUND(SUM(index_length)/(1024*1024*1024),2),'G') idx,
+  CONCAT(ROUND(SUM(data_length+index_length)/(1024*1024*1024),2),'G') total_size,
+  ROUND(SUM(index_length)/SUM(data_length),2) idxfrac
+  FROM information_schema.TABLES
+  GROUP BY engine
+  ORDER BY SUM(data_length+index_length) DESC LIMIT 10;
+SET @@global.innodb_stats_on_metadata = @current_innodb_stats_on_metadata;


### PR DESCRIPTION
This batch script is used to get logical dataset size per MySQL engine. The script can be run in batch mode or copied and pasted to MySQL console.