### PR TITLE
Multiple improvements across all scripts, README. Sychronizing with V…

### DIFF
--- a/postgresql/pg_gather/README.md
+++ b/postgresql/pg_gather/README.md
@@ -1,31 +1,28 @@
 # pg_gather
 This is a SQL-only script for gathering performance and configuration data from PostgreSQL databases 
 
-A SQL-Only script addresses the limitations of other means to collect data<br>
-This requires only `psql` (PostgreSQL client tool) connectivity to server
-
 **Supported Versions** : PostgreSQL 10, 11, 12 & 13  
 **Minimum support versions** : PostgreSQL 9.5, 9.6
 
 
 # Highlights
 1. **Secure by Open :** Simple, Transperent, Fully auditable code.<br>
-   A SQL-only script is prefered over shell scripts, executable programs from end user readablity perspective, No Programming language skills needed.
-2. **No Executables** are to be deployed on the database host<br>
+   A SQL-only data collection script. Programs with control structures are avoided for improving the readabilty and code auditability.
+2. **No Executables :** No executables need to be deployed on the database host<br>
     Usage of executables on a secured environments posses risks and not acceptable in many environments
 3. **Authentication agnostic**<br>
-   Any authentication mechanism which PostgreSQL supports should be acceptable for data gathering. So if `psql` is able to connect, data for analysis can be collected.
+   Any authentication mechanism supported by PostgreSQL works for data gathering. So if `psql` is able to connect, data for analysis can be collected.
 4. **Any Operating System** <br>
-   Linux 32 / 64 bit, SunSolaris, MAC os, Windows
+   Linux 32 / 64 bit, SunSolaris, MAC os, Windows. Works everywhere where `psql` is available
 5. **Architecture agnostic**<br>
    x86-64 bit, ARM, Sparc, Power etc
-6. **Minimal data collection** with a single text file with Tab Seperated Values (TSV)
+6. **Auditable data** : Data is collected in a text file of Tab Seperated Values (TSV) format. Which makes it possible for reviewing and auditing the information before handing over for analysis.
 7. **Any cloud** : Works with AWS RDS, Google Cloud SQL, On-Prim etc<br> 
    (Hiroku specific restrictions are addressed. Please see the note below)
 
 # How to Use
 
-## Data Gathering.
+# 1. Data Gathering.
 Inorder to gather the configuration and Performance information, the `gather.sql` script need be executed against the database using `psql` as follows
 ```
 psql <connection_parameters_if_any> -X -f gather.sql > out.txt
@@ -42,15 +39,60 @@ This output file contains performance and configuration data for analysis
    ```
      "C:\Program Files\pgAdmin 4\v4\runtime\psql.exe" -h pghost -U postgres -f gather.sql > out.txt
    ```
+## Gathering data continuosly, but Partially
+One-time data collecton may not be sufficient for capturing a problem which may not be happening at the moment. The `pg_gather` (Ver.8 onwards) offers a very simple method to capture data for analysis. The idea is to schedule `gather.sql` every minute against "template1" database. The generated output files can be collected into a directory. Here is an example of scheduling in Linux/Unix systems using cron.
+```
+* * * * * psql -h localhost -U postgres -d template1 -X -f /path/to/gather.sql > /path/to/out/out-`date +\%a-\%H.\%M`.txt 2>&1
+```
+if the connection is to `template1` database, the gather script will collect only live, dynmamic, performance related information. Which means, all the database objects specific information will be skipped. So this is referred **"Partial"** gathering.
 
-## Data Analysis
-The collected data can be imported to a PostgreSQL Instance as follows
+# 2. Data Analysis
+## 2.1 Importing collected data
+The collected data can be imported to a PostgreSQL Instance. This creates required schema objects in the `public` schema of the database  
+**CAUTION :** Please avoid using any critical environments for importing the data. A temporary PostgreSQL instance is preferable.
 ```
 sed -e '/^Pager/d; /^Tuples/d; /^Output/d; /^SELECT pg_sleep/d; /^PREPARE/d; /^\s*$/d' out.txt | psql -f gather_schema.sql -f -
 ```
+## 2.2 Generating Report
 The analysis report can be generated as follows
 ```
 psql -X -f gather_report.sql > GatherReport.html
 ```
+This HTML report can be viewed in your favourite borwser.
+
+## 2.3 Importing "*Partial*" data
+As mentioned in the previous section, partial data gathering is useful, if we ware scheduling the `gather.sql` as a simple continuous monitoring tool. The data can be imported to `history` schema.  
+The schema can be created using the `history_schema.sql` provided.
+```
+psql -X -f history_schema.sql
+```
+This project provides a sample `imphistory.sh` file which automates importing partial data from multiple files into the tables in `history` schema. This script can be executed from the directory which contains all the output files. Multiiple files and Wild cards are allowed. Here is an example:
+```
+$ ~/pg_gather/imphistory.sh out-*.txt
+```
+# ANNEXTURE 1 : Using PostgreSQL container and wrapper script
+The above mentioned steps for data analysis appears simple. However, that needs a PostgreSQL instance where the data can be imported. As an alternate option, the `generate_report.sh` script can spin up a docker container and do everything for you. It is expected to be run from the cloned repository, or a directory that has both `gather_schema.sql` and `gather_report.sql` files available.
+### How it works
+This script will spin up a docker instance, import the provided output produced by `gather.sql` and output an html report. The script expects at least a single argument: path to the `out.txt` produced by `gather.sql`. 
+
+There are two more additional positional arguments: 
+* Desired report name with path. 
+* A flag whether to keep the docker container. This allows us to use the raw data imported.
+
+Example 1: Import data and generate html file
+```
+$ ./generate_report.sh /tmp/out.txt
+...
+Container 61fbc6d15c626b484bdf70352e94bbdb821971de1e00c6de774ca5cd460e8db3 deleted
+Finished generating report in /tmp/out.txt.html
+```
+Example 2 : Import data, keep the container intact and generate report in the specified location
+```
+$ ./generate_report.sh /tmp/out.txt /tmp/custom-name.html y
+...
+Container df7b228a5a6a49586e5424e5fe7a2065d8be78e0ae3aa5cddd8658ee27f4790c left around
+Finished generating report in /tmp/custom-name.html
+```
+
 # Demonstration
 [![IMAGE ALT TEXT HERE](https://img.youtube.com/vi/k1pnXuJAl40/0.jpg)](https://www.youtube.com/watch?v=k1pnXuJAl40)

--- a/postgresql/pg_gather/gather_report.sql
+++ b/postgresql/pg_gather/gather_report.sql
@@ -23,9 +23,10 @@ SELECT (SELECT count(*) > 1 FROM pg_srvr WHERE connstr ilike 'You%') AS conlines
   \q
 \endif
 SELECT  UNNEST(ARRAY ['Collected At','Collected By','PG build', 'PG Start','In recovery?','Client','Server','Last Reload','Current LSN']) AS pg_gather,
-        UNNEST(ARRAY [collect_ts::text,usr,ver, pg_start_ts::text ||' ('|| collect_ts-pg_start_ts || ')',recovery::text,client::text,server::text,reload_ts::text,current_wal::text]) AS "Report Version V7"
+        UNNEST(ARRAY [collect_ts::text,usr,ver, pg_start_ts::text ||' ('|| collect_ts-pg_start_ts || ')',recovery::text,client::text,server::text,reload_ts::text,current_wal::text]) AS "Report Version V8"
 FROM pg_gather;
 SELECT replace(connstr,'You are connected to ','') "pg_gather Connection and PostgreSQL Server info" FROM pg_srvr; 
+\pset tableattr 'id="dbs"'
 SELECT datname DB,xact_commit commits,xact_rollback rollbacks,tup_inserted+tup_updated+tup_deleted transactions, blks_hit*100/blks_fetch  hit_ratio,temp_files,temp_bytes,db_size,age FROM pg_get_db where blks_fetch != 0;
 \pset tableattr off
 
@@ -80,7 +81,7 @@ SELECT * FROM pg_get_confs;
 \pset footer off
  SELECT d.datname,state,COUNT(pid) 
   FROM pg_get_activity a LEFT JOIN pg_get_db d on a.datid = d.datid
-    WHERE state is not null GROUP BY 1,2 ORDER BY 1;; 
+    WHERE state is not null GROUP BY 1,2 ORDER BY 1; 
 \echo <a href="#topics">Go to Topics</a>
 \echo <h2 id="time">Database time</h2>
 \echo <canvas id="chart" width="800" height="480" style="border: 1px solid black; float:right; width:75% ">Canvas is not supported</canvas>
@@ -94,14 +95,17 @@ WITH ses AS (SELECT COUNT (*) as tot, COUNT(*) FILTER (WHERE state is not null) 
 \echo <a href="#topics">Go to Topics</a>
 \pset tableattr
 \echo <h2 id="sess" style="clear: both">Session Details</h2>
-WITH w AS (SELECT pid,wait_event,count(*) cnt FROM pg_pid_wait GROUP BY 1,2 ORDER BY 1,2),
-g AS (SELECT collect_ts FROM pg_gather)
-SELECT a.pid,a.state, left(query,60) "Last statement", g.collect_ts - backend_start "Connection Since",  g.collect_ts - query_start "Statement since",g.collect_ts - state_change "State since", string_agg( w.wait_event ||':'|| w.cnt,',') waits FROM pg_get_activity a 
- JOIN w ON a.pid = w.pid
- JOIN (SELECT pid,sum(cnt) tot FROM w GROUP BY 1) s ON a.pid = s.pid
- LEFT JOIN g ON true
-WHERE a.state IS NOT NULL
-GROUP BY 1,2,3,4,5,6; 
+SELECT * FROM (
+  WITH w AS (SELECT pid,wait_event,count(*) cnt FROM pg_pid_wait GROUP BY 1,2 ORDER BY 1,2),
+  g AS (SELECT collect_ts FROM pg_gather)
+  SELECT a.pid,a.state, left(query,60) "Last statement", g.collect_ts - backend_start "Connection Since",  g.collect_ts - query_start "Statement since",g.collect_ts - state_change "State since", string_agg( w.wait_event ||':'|| w.cnt,',') waits 
+  FROM pg_get_activity a 
+   LEFT JOIN w ON a.pid = w.pid
+   LEFT JOIN (SELECT pid,sum(cnt) tot FROM w GROUP BY 1) s ON a.pid = s.pid
+   LEFT JOIN g ON true
+  WHERE a.state IS NOT NULL
+  GROUP BY 1,2,3,4,5,6) AS sess
+  WHERE waits IS NOT NULL OR state != 'idle'; 
 \echo <a href="#topics">Go to Topics</a>
 
 \echo <h2 id="blocking" style="clear: both">Blocking Sessions</h2>
@@ -223,7 +227,15 @@ FROM W;
 \echo     else  TabInd.prop("title",bytesToSize(TabIndSize));
 \echo     if (TabIndSize > 10000000000) TabInd.addClass("lime");  //Tab+Ind > 10GB
 \echo });
-
+\echo //Inspect database level info
+\echo $("#dbs tr").each(function(){
+\echo   $(this).find("td:nth-child(7),td:nth-child(8)").each(function(){
+\echo     if( Number($(this).html()) > 1048576 )  //more than 1 MB
+\echo       $(this).addClass("lime").prop("title",bytesToSize(Number($(this).html())));
+\echo   });
+\echo   //console.log($(this).children().eq(8).html());
+\echo   if (Number($(this).children().eq(8).html()) > 400000000) $(this).children().eq(8).addClass("warn").prop("title", "Age :" + Number($(this).children().eq(8).html()).toLocaleString("en-US"));
+\echo });
 \echo const getCellValue = (tr, idx) => tr.children[idx].innerText || tr.children[idx].textContent;
 \echo const comparer = (idx, asc) => (a, b) => ((v1, v2) =>   v1 !== '''''' && v2 !== '''''' && !isNaN(v1) && !isNaN(v2) ? v1 - v2 : v1.toString().localeCompare(v2))(getCellValue(asc ? a : b, idx), getCellValue(asc ? b : a, idx));
 \echo document.querySelectorAll(''''th'''').forEach(th => th.addEventListener(''''click'''', (() => {

--- a/postgresql/pg_gather/history_schema.sql
+++ b/postgresql/pg_gather/history_schema.sql
@@ -1,29 +1,8 @@
---Schema for pg_gather
-set client_min_messages=ERROR;
-DROP TABLE IF EXISTS pg_gather;
-DROP TABLE IF EXISTS pg_get_activity;
-DROP TABLE IF EXISTS pg_get_class;
-DROP TABLE IF EXISTS pg_get_confs;
-DROP TABLE IF EXISTS pg_get_db;
-DROP TABLE IF EXISTS pg_get_index;
-DROP TABLE IF EXISTS pg_get_rel;
---DROP TABLE IF EXISTS pg_get_wait;
-DROP TABLE IF EXISTS pg_srvr;
-DROP TABLE IF EXISTS pg_get_block;
-DROP TABLE IF EXISTS pg_pid_wait;
-DROP TABLE IF EXISTS pg_replication_stat;
-DROP TABLE IF EXISTS pg_archiver_stat;
-DROP TABLE IF EXISTS pg_tab_bloat;
-DROP TABLE IF EXISTS pg_get_toast;
-DROP TABLE IF EXISTS pg_get_statements;
-DROP TABLE IF EXISTS pg_get_bgwriter;
-DROP TABLE IF EXISTS pg_get_roles;
+--DROP SCHEMA IF EXISTS history CASCADE;
+CREATE SCHEMA IF NOT EXISTS history;
 
-CREATE UNLOGGED TABLE pg_srvr (
-    connstr text
-);
-
-CREATE UNLOGGED TABLE pg_gather (
+CREATE UNLOGGED TABLE IF NOT EXISTS history.pg_gather (
+    imp_ts timestamp with time zone DEFAULT CURRENT_TIMESTAMP,
     collect_ts timestamp with time zone,
     usr text,
     db text,
@@ -36,7 +15,9 @@ CREATE UNLOGGED TABLE pg_gather (
     current_wal pg_lsn
 );
 
-CREATE UNLOGGED TABLE pg_get_activity (
+
+CREATE UNLOGGED TABLE  IF NOT EXISTS  history.pg_get_activity (
+    collect_ts timestamp with time zone,
     datid oid, 
     pid integer,
     usesysid oid,
@@ -69,28 +50,16 @@ CREATE UNLOGGED TABLE pg_get_activity (
     leader_pid integer
 );
 
-CREATE UNLOGGED TABLE pg_get_statements(
-    userid oid,
-    dbid oid,
-    query text,
-    calls bigint,
-    total_time double precision
-);
-
---CREATE UNLOGGED TABLE pg_get_wait(
---    itr integer,
---    pid integer,
---    wait_event text
---);
-
-CREATE UNLOGGED TABLE pg_pid_wait(
+CREATE UNLOGGED TABLE history.pg_pid_wait(
+    collect_ts timestamp with time zone,
     itr SERIAL,
     pid integer,
     wait_event text
 );
 
 
-CREATE UNLOGGED TABLE pg_get_db (
+CREATE UNLOGGED TABLE history.pg_get_db (
+    collect_ts timestamp with time zone,
     datid oid,
     datname text,
     xact_commit bigint,
@@ -112,58 +81,8 @@ CREATE UNLOGGED TABLE pg_get_db (
     stats_reset timestamp with time zone
 );
 
-CREATE UNLOGGED TABLE pg_get_roles (
-    oid oid,
-    rolname text,
-    rolsuper boolean,
-    rolreplication boolean,
-    rolconnlimit integer,
-    rolconfig text[]
-);
-
-CREATE UNLOGGED TABLE pg_get_confs (
-    name text,
-    setting text,
-    unit text
-);
-
-CREATE UNLOGGED TABLE pg_get_class (
-    reloid oid,
-    relname text,
-    relkind char(1),
-    relnamespace oid
-);
-
-CREATE UNLOGGED TABLE pg_get_index (
-    indexrelid oid,
-    indrelid oid,
-    indisunique boolean,
-    indisprimary boolean,
-    numscans bigint,
-    size bigint
-);
---indexrelid - oid of the index
---indrelid - oid of the corresponding table
-
-CREATE UNLOGGED TABLE pg_get_rel (
-    relid oid,
-    relnamespace oid,
-    blks bigint,
-    n_live_tup bigint,
-    n_dead_tup bigint,
-    rel_size bigint,
-    tot_tab_size bigint,
-    tab_ind_size bigint,
-    rel_age bigint,
-    last_vac timestamp with time zone,
-    last_anlyze timestamp with time zone,
-    vac_nos bigint
-);
-
---rel_size is "main" fork size
---tab_size includes toast also
-
-CREATE UNLOGGED TABLE pg_get_block (
+CREATE UNLOGGED TABLE history.pg_get_block (
+    collect_ts timestamp with time zone,
     blocked_pid integer,
     blocked_user text,
     blocked_client_addr text,
@@ -184,7 +103,8 @@ CREATE UNLOGGED TABLE pg_get_block (
     blocking_xact_start timestamp with time zone
 );
 
-CREATE UNLOGGED TABLE pg_replication_stat (
+CREATE UNLOGGED TABLE history.pg_replication_stat (
+    collect_ts timestamp with time zone,
     usename text,
     client_addr text,
     client_hostname text,
@@ -196,7 +116,8 @@ CREATE UNLOGGED TABLE pg_replication_stat (
     sync_state text
 );
 
-CREATE UNLOGGED TABLE pg_archiver_stat(
+CREATE UNLOGGED TABLE history.pg_archiver_stat(
+    collect_ts timestamp with time zone,
     archived_count bigint,
     last_archived_wal text,
     last_archived_time timestamp with time zone,
@@ -204,21 +125,8 @@ CREATE UNLOGGED TABLE pg_archiver_stat(
     last_failed_time timestamp with time zone
 );
 
-
-CREATE UNLOGGED TABLE pg_get_toast(
-    relid oid,
-    toastid oid
-);
-
-
-CREATE UNLOGGED TABLE pg_tab_bloat (
-    table_oid oid,
-    tablename text,
-    relpages bigint,
-    est_pages bigint
-);
-
-CREATE UNLOGGED TABLE pg_get_bgwriter(
+CREATE UNLOGGED TABLE history.pg_get_bgwriter(
+    collect_ts timestamp with time zone,
     checkpoints_timed bigint,
     checkpoints_req  bigint,
     checkpoint_write_time double precision,
@@ -231,9 +139,3 @@ CREATE UNLOGGED TABLE pg_get_bgwriter(
     buffers_alloc bigint,
     stats_reset timestamp with time zone
 );
-
--- psql -X -f gather.sql > out.txt
--- sed -i '/^Pager/d; /^Tuples/d; /^Output/d; /^SELECT/d; /^PREPARE/d; /^$/d' out.txt; psql -f gather_schema.sql -f out.txt
-
----Report
--- psql -q -X -f gather_report.sql > out.html

--- a/postgresql/pg_gather/imphistory.sh
+++ b/postgresql/pg_gather/imphistory.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+if [ $# -eq 0 ]
+  then
+    echo "Please specify the log files as parameter. Wildcards accepted"
+fi
+for f in "$@"
+do 
+    ##Check whether the files are really the partial gather outputs
+    partial=`head -n 12 $f | grep template1 | wc -l` ;
+    ##Data collection timestamp. This info can be inserted for collect_ts of each line
+    coll_ts=`head -n 15 $f | sed -n '/COPY pg_gather/ {n; s/\([0-9-]*\s[0-9:\.+]*\).*/\1/; p}'`
+    echo
+    echo "\Importing :"$coll_ts;
+    if [ $partial = 1 ]; then
+      #import gather data and copy it to history tables
+      echo "Partial"
+
+#      Old fasioned simple replacement using sed and final multi update using CTE
+#      sed '/^Pager/d;
+#        /^Tuples/d;
+#        /^Output/d;
+#        /^SELECT pg_sleep/d;
+#        /^PREPARE/d;
+#        /^\s*$/d;
+#        s/^COPY pg_gather/COPY pg_gather (collect_ts,usr,db,ver,pg_start_ts,recovery,client,server,reload_ts,current_wal)/;
+#        s/^COPY pg_get_block/COPY pg_get_block(blocked_pid,blocked_user,blocked_client_addr,blocked_client_hostname,blocked_application_name,blocked_wait_event_type,blocked_wait_event,blocked_statement,blocked_xact_start,blocking_pid,blocking_user,blocking_user_addr,blocking_client_hostname,blocking_application_name,blocking_wait_event_type,blocking_wait_event,statement_in_blocking_process,blocking_xact_start)/;
+#        s/^COPY pg_replication_stat/COPY pg_replication_stat(usename,client_addr,client_hostname,state,sent_lsn,write_lsn,flush_lsn,replay_lsn,sync_state)/;
+#        s/^COPY pg_archiver_stat/COPY pg_archiver_stat(archived_count,last_archived_wal,last_archived_time,last_failed_wal,last_failed_time)/;
+#        s/^COPY pg_get_bgwriter/COPY pg_get_bgwriter(checkpoints_timed,checkpoints_req,checkpoint_write_time,checkpoint_sync_time,buffers_checkpoint,buffers_clean,maxwritten_clean,buffers_backend,buffers_backend_fsync,buffers_alloc,stats_reset)/
+#        $aWITH collect AS (SELECT collect_ts FROM history.pg_gather WHERE imp_ts = (SELECT max(imp_ts) from history.pg_gather)), \
+#         updateactivity AS (UPDATE history.pg_get_activity SET collect_ts = (SELECT collect_ts FROM collect) WHERE collect_ts IS NULL), \
+#         updatedb AS (UPDATE history.pg_get_db SET collect_ts = (SELECT collect_ts FROM collect) WHERE collect_ts IS NULL), \
+#         updatewait AS (UPDATE history.pg_pid_wait SET collect_ts = (SELECT collect_ts FROM collect) WHERE collect_ts IS NULL), \
+#         updateblock AS (UPDATE history.pg_get_block SET collect_ts = (SELECT collect_ts FROM collect) WHERE collect_ts IS NULL), \
+#         updatebgwriter AS (UPDATE history.pg_get_bgwriter SET collect_ts = (SELECT collect_ts FROM collect) WHERE collect_ts IS NULL), \
+#         updatearchiver AS (UPDATE history.pg_archiver_stat SET collect_ts = (SELECT collect_ts FROM collect) WHERE collect_ts IS NULL), \
+#         updatereplication AS (UPDATE history.pg_replication_stat SET collect_ts = (SELECT collect_ts FROM collect) WHERE collect_ts IS NULL) \
+#         SELECT collect_ts,(SELECT count(*) FROM history.pg_gather) FROM collect;' \
+#        $f | psql "options='-c search_path=history -c synchronous_commit=off'"  -f - 
+
+# An alternate and more elegent solution (19-Jun-2021) to take out only COPY statement manipulate
+        sed -n '
+        /^COPY/, /^\\\./ {
+          s/COPY pg_get_activity (/COPY pg_get_activity (collect_ts,/
+          s/COPY pg_pid_wait (/COPY pg_pid_wait (collect_ts,/
+          s/COPY pg_get_db (/COPY pg_get_db (collect_ts,/
+          /^COPY\|\\\./! s/\(.*\)/'"$coll_ts"\\t'\1/g
+          p
+        }' $f | psql "options='-c search_path=history -c synchronous_commit=off'"  -f - 
+#        /^Output/d
+#        /^PREPARE/d
+
+    else
+      echo "Full"
+    fi
+done


### PR DESCRIPTION
This is based on the Version 8 release of the pg_gather project.
* Upto 20% space saving in the output file.  Redirects unnecessary output to  null device wherever possible 
* Improvements to `gather.sql`  for scheduling it against `template1` database for partial data gathering. which works as simple continuous monitoring.
* New history schema and history import script
* Multiple Improvements to the bulk import of partial data to history tables. New sed script extracts the COPY commands and feeds the psql. Method of CTEs and bulk updates are avoided.
* All tables are converted into UNLOGGED because the data is temporary in nature. Improves the speed especially when PostgreSQL runs in small VMs / containers.
* Improvements to README based on feedback. New sections for Partial data collection and importing data.
* Cleanup/remove pg_get_wait which is no longer used.
* Improvement to analytical query and gather_old.sql patched for latest schema

