### PR TITLE
Sync with Release 13

### DIFF
--- a/postgresql/pg_gather/analysis_queries.sql
+++ b/postgresql/pg_gather/analysis_queries.sql
@@ -1,18 +1,137 @@
----What is idle in transaction sessions are doing.
-SELECT wait_event,count(*) FROM pg_pid_wait
-WHERE pid in (select pid from pg_get_activity where state='idle in transaction')
-GROUP BY wait_event ORDER BY 2;
+--1. What is idle in transaction sessions are doing.
+SELECT 
+--   pg_get_activity.pid,pg_get_activity.query,
+   pg_pid_wait.wait_event,count(*) 
+FROM pg_pid_wait
+JOIN pg_get_activity ON pg_pid_wait.pid = pg_get_activity.pid
+WHERE state='idle in transaction'
+GROUP BY 1 ORDER BY 2;
 
----Which session is at the top of the blocking
-select blocking_pid,statement_in_blocking_process,count(*)
- from pg_get_block where blocking_pid not in (select blocked_pid from pg_get_block)
- group by 1,2;
+--2.User, database, Active, Total connection (Need for pgbouncer setup)
+SELECT 
+rolname,datname,count(*) FILTER (WHERE state='active') as active,
+count(*) FILTER (WHERE state='idle in transaction') as idle_in_transaction,
+count(*) FILTER (WHERE state='idle') as idle,
+count(*) 
+FROM pg_get_activity 
+  join pg_get_roles on usesysid=pg_get_roles.oid
+  join pg_get_db on pg_get_activity.datid = pg_get_db.datid
+GROUP BY ROLLUP(1,2)
+ORDER BY 1,2;
+
+--3.Which session is at the top of the blocking
+SELECT blocking_pid,statement_in_blocking_process,count(*)
+ FROM pg_get_block WHERE blocking_pid not in (SELECT blocked_pid FROM pg_get_block)
+ GROUP by 1,2;
+
+--4.Biggest Blockers
+SELECT statement_in_blocking_process,count(*) FROM  pg_get_block GROUP BY 1 ORDER BY 2;
+
+--5.What is the status of the blocking pids (This may not be accurate as there is 20 second time difference)
+SELECT pid,state FROM pg_get_activity WHERE pid IN
+(SELECT blocking_pid FROM (SELECT blocking_pid,statement_in_blocking_process,count(*)
+ from pg_get_block WHERE blocking_pid not in (SELECT blocked_pid FROM pg_get_block)
+ GROUP by 1,2) blockers);
+
+--6.Wait event associated with blocking session (Important)
+SELECT blocking_pid,blocking_wait_event,count(*)
+ from pg_get_block WHERE blocking_pid not in (SELECT blocked_pid FROM pg_get_block)
+ GROUP BY 1,2;
 
 
---TOP 5 Tables which require maximum maintenace memory
-WITH top_tabs AS (select relid,n_live_tup*0.2*6/1024/1024/1024 maint_work_mem_gb 
-   from pg_get_rel order by 2 desc limit 5)
+--7.TOP 5 Tables which require maximum maintenace memory
+WITH top_tabs AS (SELECT relid,n_live_tup*0.2*6/1024/1024/1024 maint_work_mem_gb 
+   from pg_get_rel ORDER BY 2 DESC LIMIT 5)
 SELECT relid, relname,maint_work_mem_gb
  FROM top_tabs
  JOIN pg_get_class ON top_tabs.relid = pg_get_class.reloid
 ORDER BY 3 DESC;
+
+--8. Stats reset info.
+SELECT datname,stats_reset FROM pg_get_db WHERE stats_reset is not null;
+SELECT stats_reset FROM pg_get_bgwriter;
+
+--9. Cache hit on databases
+SELECT datname, 100 * blks_hit / blks_fetch as cache_hit_ratio FROM pg_get_db WHERE blks_fetch > 0;
+
+--10. All table information
+SELECT c.relname "Name",c.relkind "Kind",r.relnamespace "Schema",r.blks,r.n_live_tup "Live tup",r.n_dead_tup "Dead tup", CASE WHEN r.n_live_tup <> 0 THEN  ROUND((r.n_dead_tup::real/r.n_live_tup::real)::numeric,4) END "Dead/Live",
+r.rel_size "Rel size",r.tot_tab_size "Tot.Tab size",r.tab_ind_size "Tab+Ind size",r.rel_age,r.last_vac "Last vacuum",r.last_anlyze "Last analyze",r.vac_nos,
+ct.relname "Toast name",rt.tab_ind_size "Toast+Ind" ,rt.rel_age "Toast Age",GREATEST(r.rel_age,rt.rel_age) "Max age"
+FROM pg_get_rel r
+JOIN pg_get_class c ON r.relid = c.reloid AND c.relkind NOT IN ('t','p')
+LEFT JOIN pg_get_toast t ON r.relid = t.relid
+LEFT JOIN pg_get_class ct ON t.toastid = ct.reloid
+LEFT JOIN pg_get_rel rt ON rt.relid = t.toastid
+ORDER BY r.tab_ind_size DESC;
+
+-- 11. All index information
+SELECT ct.relname AS "Table", ci.relname as "Index",indisunique,indisprimary,numscans,size
+  FROM pg_get_index i 
+  JOIN pg_get_class ct on i.indrelid = ct.reloid and ct.relkind != 't'
+  JOIN pg_get_class ci ON i.indexrelid = ci.reloid
+ORDER BY size DESC;
+
+-- 12. Compile time parameter changes
+SELECT * FROM pg_get_confs cnf
+JOIN
+(VALUES ('block_size','8192'),('max_identifier_length','63'),('max_function_args','100'),('max_index_keys','32'),('segment_size','131072'),('wal_block_size','8192'),('wal_segment_size','16777216')) AS T (name,setting)
+ON cnf.name = T.name and cnf.setting != T.setting;
+
+
+=======================HISTORY SCHEMA ANALYSIS=========================
+set timezone=UTC;
+--Start and End time of data collection
+SELECT min(collect_ts),max(collect_ts) FROM history.pg_get_activity ;
+--min and max of a particular hour : WHERE DATE_TRUNC('hour',collect_ts) = '2022-01-03 18:00:00+00';
+
+--Inspect the continuity of data collection, whether there is any gap
+SELECT DATE_TRUNC('hour',collect_ts) date_hour,count(*) cnt FROM history.pg_get_activity GROUP BY DATE_TRUNC('hour',collect_ts) ORDER BY 1;
+
+---Load over a perioid of time
+SELECT collect_ts,count(*) FILTER (WHERE state='active') as active,count(*) FILTER (WHERE state='idle in transaction') as idle_in_transaction,
+count(*) FILTER (WHERE state='idle') as idle,count(*) connections  FROM history.pg_get_activity GROUP by collect_ts ORDER BY 1;
+--Or use CAST(collect_ts as time) if data is for a single day
+
+--More details about the connections
+SELECT rolname,datname,state,client_addr,count(*) FROM 
+ pg_get_activity a 
+ left join pg_get_roles r on a.usesysid = r.oid
+ left join pg_get_db d USING (datid)
+GROUP BY rolname,datname,state,client_addr
+ORDER BY count(*);
+
+
+
+
+
+--HISTORY (BULK DATA IMPORT)
+
+WITH w AS (SELECT collect_ts,COALESCE(wait_event,'CPU') as wait_event,count(*) cnt FROM history.pg_pid_wait GROUP BY 1,2 ORDER BY 1,2)
+SELECT w.collect_ts,string_agg( w.wait_event ||':'|| w.cnt,',' ORDER BY w.cnt DESC) "wait events" 
+FROM w 
+WHERE w.collect_ts between '2022-01-03 16:46:01.213361+00' AND '2022-01-03 16:48:01.657648+00 '
+GROUP BY w.collect_ts;
+
+--
+SELECT rolname,datname,state,count(*) from 
+ history.pg_get_activity a 
+ left join pg_get_roles r on a.usesysid = r.oid
+ left join pg_get_db d USING (datid)
+WHERE collect_ts between '2021-12-27 16:32:01' and '2021-12-27 16:36:01' GROUP BY rolname,datname,state
+ORDER BY count(*);
+
+--Top 5 active sessions
+SELECT collect_ts,count(*) FROM history.pg_get_activity WHERE state='active' GROUP BY collect_ts ORDER BY count(*) DESC LIMIT 5;
+--Idle in transactions
+SELECT collect_ts,count(*) FROM history.pg_get_activity WHERE state like 'idle in transaction%' GROUP by collect_ts ORDER BY count(*) DESC LIMIT 5;
+
+SELECT wait_event,count(*) FROM history.pg_pid_wait WHERE collect_ts='2021-06-28 14:02:01.324049+00'
+ and pid in (SELECT pid FROM history.pg_get_activity WHERE collect_ts='2021-06-28 14:02:01.324049+00' and state like 'idle in transaction%')
+GROUP BY wait_event;
+
+
+SELECT distinct collect_ts FROM history.pg_get_activity WHERE collect_ts < '2021-07-18' ORDER BY 1;
+SELECT 'DELETE FROM '||n.nspname||'.'||relname||' WHERE collect_ts < ''2021-07-18''' FROM pg_class c join pg_namespace n ON n.oid = c.relnamespace and n.nspname = 'history';
+
+

--- a/postgresql/pg_gather/gather.sql
+++ b/postgresql/pg_gather/gather.sql
@@ -1,10 +1,10 @@
 ---- pg_gather : Gather Performance Metics and PostgreSQL Configuration
 ---- For Revision History : https://github.com/jobinau/pg_gather/releases
 -- pg_gather version
-\set ver 12
+\set ver 13
 \echo '\\set ver ':ver
 --Detect PG versions and type of gathering
-SELECT ( :SERVER_VERSION_NUM > 120000 ) AS pg12, ( :SERVER_VERSION_NUM > 130000 ) AS pg13, ( current_database() != 'template1' ) as fullgather \gset
+SELECT ( :SERVER_VERSION_NUM > 120000 ) AS pg12, ( :SERVER_VERSION_NUM > 130000 ) AS pg13, ( :SERVER_VERSION_NUM > 140000 ) AS pg14, ( current_database() != 'template1' ) as fullgather \gset
 
 \if :fullgather
 ---Error out and exit, unless healthy
@@ -45,7 +45,9 @@ CASE WHEN pg_is_in_recovery() THEN pg_last_wal_receive_lsn() ELSE pg_current_wal
 ) TO stdin; 
 \echo '\\.'
 
-\if :pg13
+\if :pg14
+    \echo COPY pg_get_activity (datid, pid ,usesysid ,application_name ,state ,query ,wait_event_type ,wait_event ,xact_start ,query_start ,backend_start ,state_change ,client_addr, client_hostname, client_port, backend_xid ,backend_xmin, backend_type,ssl ,sslversion ,sslcipher ,sslbits ,ssl_client_dn ,ssl_client_serial,ssl_issuer_dn ,gss_auth ,gss_princ ,gss_enc,leader_pid,query_id) FROM stdin;
+\elif :pg13
     \echo COPY pg_get_activity (datid, pid ,usesysid ,application_name ,state ,query ,wait_event_type ,wait_event ,xact_start ,query_start ,backend_start ,state_change ,client_addr, client_hostname, client_port, backend_xid ,backend_xmin, backend_type,ssl ,sslversion ,sslcipher ,sslbits ,sslcompression ,ssl_client_dn ,ssl_client_serial,ssl_issuer_dn ,gss_auth ,gss_princ ,gss_enc,leader_pid) FROM stdin;
 \elif :pg12
     \echo COPY pg_get_activity (datid, pid ,usesysid ,application_name ,state ,query ,wait_event_type ,wait_event ,xact_start ,query_start ,backend_start ,state_change ,client_addr, client_hostname, client_port, backend_xid ,backend_xmin, backend_type,ssl ,sslversion ,sslcipher ,sslbits ,sslcompression ,ssl_client_dn ,ssl_client_serial,ssl_issuer_dn ,gss_auth ,gss_princ ,gss_enc) FROM stdin;

--- a/postgresql/pg_gather/gather_report.sql
+++ b/postgresql/pg_gather/gather_report.sql
@@ -9,6 +9,7 @@
 \echo tr:hover { background-color: #FFFFCA}
 \echo caption { font-size: larger }
 \echo .warn { font-weight:bold; background-color: #FAA }
+\echo .high { border: 5px solid red;}
 \echo .lime { font-weight:bold}
 \echo .lineblk {float: left; margin:5px }
 \echo </style>
@@ -33,7 +34,7 @@ SELECT (SELECT count(*) > 1 FROM pg_srvr WHERE connstr ilike 'You%') AS conlines
 \endif
 WITH TZ AS (SELECT set_config('timezone',setting,false) AS val FROM  pg_get_confs WHERE name='log_timezone')
 SELECT  UNNEST(ARRAY ['Collected At','Collected By','PG build', 'PG Start','In recovery?','Client','Server','Last Reload','Current LSN']) AS pg_gather,
-        UNNEST(ARRAY [collect_ts::text||' ('||TZ.val||')',usr,ver, pg_start_ts::text ||' ('|| collect_ts-pg_start_ts || ')',recovery::text,client::text,server::text,reload_ts::text,current_wal::text]) AS "Report Version V12"
+        UNNEST(ARRAY [collect_ts::text||' ('||TZ.val||')',usr,ver, pg_start_ts::text ||' ('|| collect_ts-pg_start_ts || ')',recovery::text,client::text,server::text,reload_ts::text,current_wal::text]) AS "Report Version V13"
 FROM pg_gather JOIN TZ ON TRUE;
 SELECT replace(connstr,'You are connected to ','') "pg_gather Connection and PostgreSQL Server info" FROM pg_srvr; 
 \pset tableattr 'id="dbs"'
@@ -113,31 +114,34 @@ SELECT COALESCE(wait_event,'CPU') "Event", count(*)::text FROM pg_pid_wait GROUP
 \C
 --session waits 
 \echo <a href="#topics">Go to Topics</a>
-\pset tableattr
 \echo <h2 id="sess" style="clear: both">Session Details</h2>
+\pset tableattr 'id="tblsess"' 
 SELECT * FROM (
   WITH w AS (SELECT pid,COALESCE(wait_event,'CPU') wait_event,count(*) cnt FROM pg_pid_wait GROUP BY 1,2 ORDER BY 1,2),
-  g AS (SELECT MAX(state_change) as ts FROM pg_get_activity)
-  SELECT a.pid,a.state, left(query,60) "Last statement", g.ts - backend_start "Connection Since", g.ts - xact_start "Transaction Since",  g.ts - query_start "Statement since",g.ts - state_change "State since", string_agg( w.wait_event ||':'|| w.cnt,',') waits 
+  g AS (SELECT MAX(state_change) as ts,MAX(GREATEST(backend_xid::text::bigint,backend_xmin::text::bigint)) mx_xid FROM pg_get_activity)
+  SELECT a.pid,a.state, left(query,60) "Last statement", g.ts - backend_start "Connection Since", g.ts - xact_start "Transaction Since", g.mx_xid - backend_xmin::text::bigint "xmin age",
+   g.ts - query_start "Statement since",g.ts - state_change "State since", string_agg( w.wait_event ||':'|| w.cnt,',') waits 
   FROM pg_get_activity a 
    LEFT JOIN w ON a.pid = w.pid
    LEFT JOIN (SELECT pid,sum(cnt) tot FROM w GROUP BY 1) s ON a.pid = s.pid
    LEFT JOIN g ON true
   WHERE a.state IS NOT NULL
-  GROUP BY 1,2,3,4,5,6,7) AS sess
+  GROUP BY 1,2,3,4,5,6,7,8 ) AS sess
 WHERE waits IS NOT NULL OR state != 'idle'; 
 \echo <a href="#topics">Go to Topics</a>
 \echo <h2 id="blocking" style="clear: both">Blocking Sessions</h2>
-SELECT * FROM pg_get_block;
+\pset tableattr 'id="tblblk"'
+SELECT * FROM pg_get_block; 
 \echo <a href="#topics">Go to Topics</a>
 \echo <h2 id="statements" style="clear: both">Top 10 Statements</h2>
-
+\pset tableattr 'id="tblstmnt"'
 \C 'Statements consuming highest database time. Consider information from pg_get_statements for other criteria'
 select query,total_time,calls from pg_get_statements order by 2 desc limit 10; 
 \C 
 \echo <a href="#topics">Go to Topics</a>
 \echo <h2 id="bgcp" style="clear: both">Background Writer and Checkpointer Information</h2>
 \echo <p>Efficiency of Background writer and Checkpointer Process</p>
+\pset tableattr 'id="tblchkpnt"'
 SELECT round(checkpoints_req*100/tot_cp,1) "Forced Checkpoint %" ,
 round(min_since_reset/tot_cp,2) "avg mins between CP",
 round(checkpoint_write_time::numeric/(tot_cp*1000),4) "Avg CP write time (s)",
@@ -219,6 +223,10 @@ SELECT 'ERROR :'||error ||': '||name||' with setting '||setting||' in '||sourcef
 \echo   if (i === 0) return bytes + sizes[i];
 \echo   return (bytes / (divisor ** i)).toFixed(1) + sizes[i]; 
 \echo }
+\echo function DurationtoSeconds(duration){
+\echo     const [hours, minutes, seconds] = duration.split(":");
+\echo     return Number(hours) * 60 * 60 + Number(minutes) * 60 + Number(seconds);
+\echo };
 \echo autovacuum_freeze_max_age = 0; //Number($("#params td:contains('autovacuum_freeze_max_age')").parent().children().eq(1).text());
 \echo function checkpars(){   //parameter checking
 \echo $("#params tr").each(function(){
@@ -317,6 +325,26 @@ SELECT 'ERROR :'||error ||': '||name||' with setting '||setting||' in '||sourcef
 \echo $("#tableConten tr").each(function(){
 \echo   evnts = $(this).children().eq(1);
 \echo   if (Number(evnts.html()) > 0 )  evnts.append(''''<div style="display:inline-block;width:' + Number(evnts.html())*1500/maxevnt + 'px; border: 7px outset brown">'''');
+\echo });
+\echo let blokers = []
+\echo let blkvictims = []
+\echo $("#tblblk tr").each(function(){
+\echo   victim =$(this).children().eq(0).text();
+\echo   blkr =$(this).children().eq(9).text();
+\echo   if (victim > 0) blkvictims.push(victim);
+\echo   if (blkr > 0) blokers.push(blkr);
+\echo });
+\echo //Session information.
+\echo $("#tblsess tr").each(function(){
+\echo   pid = $(this).children().eq(0);
+\echo   stime = $(this).children().eq(7);
+\echo   xidage = $(this).children().eq(5);
+\echo   if (xidage.text() > 20) xidage.addClass("warn");
+\echo   if (blokers.indexOf(pid.text()) > -1){ 
+\echo      pid.addClass("warn").prop("title","Blocker")
+\echo      if (blkvictims.indexOf(pid.text()) == -1) pid.addClass("high");
+\echo   };
+\echo   if(DurationtoSeconds(stime.text()) > 300) stime.addClass("warn").prop("title","Busy");
 \echo });
 \echo $(document).keydown(function(event) {  //Scroll to Index/Topics if Alt+I is pressed
 \echo     if (event.altKey && event.which === 73)

--- a/postgresql/pg_gather/gather_schema.sql
+++ b/postgresql/pg_gather/gather_schema.sql
@@ -68,7 +68,8 @@ CREATE UNLOGGED TABLE pg_get_activity (
     gss_auth boolean,
     gss_princ text,
     gss_enc boolean,
-    leader_pid integer
+    leader_pid integer,
+    query_id bigint
 );
 
 CREATE UNLOGGED TABLE pg_get_statements(


### PR DESCRIPTION
* Version detection of PG 14 is introduced
* PG 14 introduces the query_id in pg_stat_activitiy. Now pg_gather collect the same for analysis
* `sslcompression` is no longer available for PG 14.
* backend xmin age will be highlighted if it  getting older than 20 transactions
* New border highlight CSS for highly important items
* Top of the blockers will be highlighted with red border.
* All blockers will be highlighted with red background
* Rollup querry for session summary
* Source Code improvement - SQL Keywords 
* Source Code improvements - pg_get_class filelds are explicity specified for the purpose of capturing relpersistence in future. objects from temp schema is not longer eleminated