### PR TITLE
Sync with v21 release

### DIFF
--- a/postgresql/pg_gather/gather.sql
+++ b/postgresql/pg_gather/gather.sql
@@ -1,7 +1,7 @@
 ---- pg_gather : Gather Performance Metics and PostgreSQL Configuration
 ---- For Revision History : https://github.com/jobinau/pg_gather/releases
 -- pg_gather version
-\set ver 20
+\set ver 21
 \echo '\\set ver ':ver
 --Detect PG versions and type of gathering
 SELECT ( :SERVER_VERSION_NUM > 120000 ) AS pg12, ( :SERVER_VERSION_NUM > 130000 ) AS pg13, ( :SERVER_VERSION_NUM > 140000 ) AS pg14, ( current_database() != 'template1' ) as fullgather \gset
@@ -120,8 +120,8 @@ COPY (SELECT oid,relname,relkind,relnamespace,relpersistence,reloptions FROM pg_
 \echo '\\.'
 
 --Index usage info
-\echo COPY pg_get_index(indexrelid,indrelid,indisunique,indisprimary,numscans,size) FROM stdin;
-COPY (SELECT indexrelid,indrelid,indisunique,indisprimary, pg_stat_get_numscans(indexrelid),pg_table_size(indexrelid) from pg_index) TO stdin;
+\echo COPY pg_get_index(indexrelid,indrelid,indisunique,indisprimary,indisvalid,numscans,size) FROM stdin;
+COPY (SELECT indexrelid,indrelid,indisunique,indisprimary,indisvalid, pg_stat_get_numscans(indexrelid),pg_table_size(indexrelid) from pg_index) TO stdin;
 \echo '\\.'
 
 --Table usage Information 
@@ -160,6 +160,11 @@ JOIN pg_namespace nn ON cc.relnamespace = nn.oid AND nn.nspname <> 'information_
 --TOAST info
 \echo COPY pg_get_toast FROM stdin;
 COPY (SELECT oid, reltoastrelid FROM pg_class WHERE reltoastrelid != 0 ) TO stdin;
+\echo '\\.'
+
+--Partitioning
+\echo COPY pg_get_inherits (inhrelid,inhparent) FROM stdin;
+COPY (SELECT inhrelid,inhparent FROM pg_inherits) TO stdin;
 \echo '\\.'
 
 --namespaces/schemas

--- a/postgresql/pg_gather/gather_report.sql
+++ b/postgresql/pg_gather/gather_report.sql
@@ -9,9 +9,9 @@
 \echo h2 { scroll-margin-left: 2em;} /*keep the scroll left*/
 \echo caption { font-size: larger }
 \echo ol { width: fit-content;}
-\echo .warn { font-weight:bold; background-color: #FAA }
+\echo .warn { font-weight:bold; background-color: #FBA }
 \echo .high { border: 5px solid red;font-weight:bold}
-\echo .lime { font-weight:bold}
+\echo .lime { font-weight:bold;background-color: #FFD}
 \echo .lineblk {float: left; margin:0 9px 4px 0 }
 \echo .bottomright { position: fixed; right: 0px; bottom: 0px; padding: 5px; border : 2px solid #AFAFFF; border-radius: 5px;}
 \echo .thidden tr td:nth-child(2), .thidden th:nth-child(2) {display: none;}
@@ -48,10 +48,10 @@ SELECT * FROM
     ELSE  set_config('timezone',:'tzone',false) 
   END AS val)
 SELECT  UNNEST(ARRAY ['Collected At','Collected By','PG build', 'PG Start','In recovery?','Client','Server','Last Reload','Current LSN']) AS pg_gather,
-        UNNEST(ARRAY [CONCAT(collect_ts::text,' (',TZ.val,')'),usr,ver, pg_start_ts::text ||' ('|| collect_ts-pg_start_ts || ')',recovery::text,client::text,server::text,reload_ts::text,current_wal::text]) AS "Report-v20"
+        UNNEST(ARRAY [CONCAT(collect_ts::text,' (',TZ.val,')'),usr,ver, pg_start_ts::text ||' ('|| collect_ts-pg_start_ts || ')',recovery::text,client::text,server::text,reload_ts::text,current_wal::text]) AS "Report-v21"
 FROM pg_gather LEFT JOIN TZ ON TRUE 
 UNION
-SELECT  'Connection', replace(connstr,'You are connected to ','') FROM pg_srvr ) a WHERE "Report-v20" IS NOT NULL ORDER BY 1;
+SELECT  'Connection', replace(connstr,'You are connected to ','') FROM pg_srvr ) a WHERE "Report-v21" IS NOT NULL ORDER BY 1;
 \pset tableattr 'id="dbs" class="thidden"'
 WITH cts AS (SELECT COALESCE(collect_ts,(SELECT max(state_change) FROM pg_get_activity)) AS c_ts FROM pg_gather)
 SELECT datname "DB Name",to_jsonb(ROW(tup_inserted/days,tup_updated/days,tup_deleted/days,to_char(stats_reset,'YYYY-MM-DD HH24-MI-SS')))
@@ -79,7 +79,7 @@ FROM pg_get_db LEFT JOIN LATERAL (SELECT GREATEST((EXTRACT(epoch FROM(c_ts-stats
 \echo <li><a href="#indexes">Indexes</a></li>
 \echo <li><a href="#parameters">Parameters / Settings</a></li>
 \echo <li><a href="#extensions">Extensions</a></li>
-\echo <li><a href="#activiy">Sessions Summary</a></li>
+\echo <li><a href="#activiy">Connection Summary</a></li>
 \echo <li><a href="#time">Database Time</a></li>
 \echo <li><a href="#sess">Session Details</a></li>
 \echo <li><a href="#blocking">Blocking Sessions</a></li>
@@ -127,11 +127,12 @@ FROM pg_get_confs s FULL OUTER JOIN pg_get_file_confs f ON lower(s.name) = lower
 GROUP BY 1,2,3,4 ORDER BY 1; 
 \pset tableattr
 \echo <h2 id="extensions">Extensions</h2>
+\pset tableattr 'id="tblextn"'
 SELECT ext.oid,extname,rolname as owner,extnamespace,extrelocatable,extversion FROM pg_get_extension ext
 JOIN pg_get_roles on extowner=pg_get_roles.oid; 
-\echo <h2 id="activiy">Session Summary</h2>
+\echo <h2 id="activiy">Connection Summary</h2>
 \pset footer off
-\pset tableattr 'id="tblss"'
+\pset tableattr 'id="tblcs"'
  SELECT d.datname,state,COUNT(pid) 
   FROM pg_get_activity a LEFT JOIN pg_get_db d on a.datid = d.datid
     WHERE state is not null GROUP BY 1,2 ORDER BY 1; 
@@ -139,23 +140,32 @@ JOIN pg_get_roles on extowner=pg_get_roles.oid;
 \pset tableattr 'id="tableConten" name="waits"'
 \C 'Wait Events and CPU info.'
 SELECT COALESCE(wait_event,'CPU') "Event", count(*)::text FROM pg_pid_wait
-WHERE wait_event IS NULL OR wait_event NOT IN ('ArchiverMain','AutoVacuumMain','BgWriterHibernate','BgWriterMain','CheckpointerMain','LogicalApplyMain','LogicalLauncherMain','RecoveryWalStream','SysLoggerMain','WalReceiverMain','WalSenderMain','WalWriterMain','CheckpointWriteDelay','PgSleep')
+WHERE wait_event IS NULL OR wait_event NOT IN ('ArchiverMain','AutoVacuumMain','BgWriterHibernate','BgWriterMain','CheckpointerMain','LogicalApplyMain','LogicalLauncherMain','RecoveryWalStream','SysLoggerMain','WalReceiverMain','WalSenderMain','WalWriterMain','CheckpointWriteDelay','PgSleep','VacuumDelay')
 GROUP BY 1 ORDER BY count(*) DESC;
 \C
 
 \echo <a href="https://github.com/jobinau/pg_gather/blob/main/docs/waitevents.md">Wait Event Reference</a>
 \echo <h2 id="sess" style="clear: both">Session Details</h2>
-\pset tableattr 'id="tblsess"' 
+\pset tableattr 'id="tblsess" class="thidden"' 
 SELECT * FROM (
-  WITH w AS (SELECT pid,COALESCE(wait_event,'CPU') wait_event,count(*) cnt FROM pg_pid_wait GROUP BY 1,2 ORDER BY 1,2),
-  g AS (SELECT MAX(state_change) as ts,MAX(GREATEST(backend_xid::text::bigint,backend_xmin::text::bigint)) mx_xid FROM pg_get_activity)
-  SELECT a.pid,a.state,r.rolname "User",client_addr "From", CASE query WHEN '' THEN '**'||backend_type||' process**' ELSE query END "Last statement", g.ts - backend_start "Connection Since", g.ts - xact_start "Transaction Since", g.mx_xid - backend_xmin::text::bigint "xmin age",
-   g.ts - query_start "Statement since",g.ts - state_change "State since", string_agg( w.wait_event ||':'|| w.cnt,',') waits 
+    WITH w AS (SELECT pid, string_agg( wait_event ||':'|| cnt,',') waits, sum(cnt) pidwcnt, max(max) itr_max, min(min) itr_min FROM
+    (SELECT pid,COALESCE(wait_event,'CPU') wait_event,count(*) cnt, max(itr),min(itr) FROM pg_pid_wait GROUP BY 1,2 ORDER BY cnt DESC) pw GROUP BY 1),
+  g AS (SELECT MAX(state_change) as ts,MAX(GREATEST(backend_xid::text::bigint,backend_xmin::text::bigint)) mx_xid FROM pg_get_activity),
+  itr AS (SELECT max(itr_max) gitr_max FROM w)
+  SELECT a.pid,to_jsonb(ROW(d.datname,application_name,client_hostname,sslversion)), a.state,r.rolname "User",client_addr "client"
+  , CASE query WHEN '' THEN '**'||backend_type||' process**' ELSE query END "Last statement"
+  , g.ts - backend_start "Connection Since", g.ts - xact_start "Transaction Since", g.mx_xid - backend_xmin::text::bigint "xmin age",
+   g.ts - query_start "Statement since",g.ts - state_change "State since", w.waits ||
+   CASE WHEN (itr_max - itr_min)::float/itr.gitr_max*2000 - pidwcnt > 0 THEN
+    ', Net/Delay*:' || ((itr_max - itr_min)::float/itr.gitr_max*2000 - pidwcnt)::int
+   ELSE '' END waits
   FROM pg_get_activity a 
    LEFT JOIN w ON a.pid = w.pid
+   LEFT JOIN itr ON true
    LEFT JOIN g ON true
    LEFT JOIN pg_get_roles r ON a.usesysid = r.oid
-  GROUP BY 1,2,3,4,5,6,7,8,9,10 ORDER BY 8 DESC NULLS LAST) AS sess
+   LEFT JOIN pg_get_db d on a.datid = d.datid
+  ORDER BY "xmin age" DESC NULLS LAST) AS sess
 WHERE waits IS NOT NULL OR state != 'idle';
 \echo <h2 id="blocking" style="clear: both">Blocking Sessions</h2>
 \pset tableattr 'id="tblblk"'
@@ -203,13 +213,13 @@ round(min_since_reset/(60*24),1) "Reset days"
 FROM pg_get_bgwriter
 CROSS JOIN 
 (SELECT 
-    round(extract('epoch' from (select collect_ts from pg_gather) - stats_reset)/60)::numeric min_since_reset,
+    NULLIF(round(extract('epoch' from (select collect_ts from pg_gather) - stats_reset)/60)::numeric,0) min_since_reset,
     GREATEST(buffers_checkpoint + buffers_clean + buffers_backend,1) total_buffers,
-    checkpoints_timed+checkpoints_req tot_cp 
+    NULLIF(checkpoints_timed+checkpoints_req,0) tot_cp 
     FROM pg_get_bgwriter) AS bg
 LEFT JOIN pg_get_confs delay ON delay.name = 'bgwriter_delay'
 LEFT JOIN pg_get_confs lru ON lru.name = 'bgwriter_lru_maxpages'; 
-\echo <p>**1 What percentage of bgwriter runs results in a halt, **2 What percentage of bgwriter halts are due to hitting on <code>bgwriter_lru_maxpages</code> limit</p>
+\echo <p>**1 Percentage of bgwriter runs results in a halt, **2 Percentage of bgwriter halts are due to hitting on <code>bgwriter_lru_maxpages</code> limit</p>
 \echo <h2 id="findings" >Findings</h2>
 \echo <ol id="finditem" style="padding:2em;position:relative">
 \pset format aligned
@@ -218,11 +228,6 @@ WITH W AS (SELECT COUNT(*) AS val FROM pg_get_activity WHERE state='idle in tran
 SELECT CASE WHEN val > 0 
   THEN '<li>There are '||val||' idle in transaction session(s) </li>' 
   ELSE NULL END 
-FROM W; 
-WITH W AS (SELECT count(*) AS val from pg_get_rel r JOIN pg_get_class c ON r.relid = c.reloid AND c.relkind NOT IN ('t','p'))
-SELECT CASE WHEN val > 10000
-  THEN '<li>There are <b>'||val||' tables!</b> in this database, Only the biggest 10000 will be listed in this report under <a href= "#tabInfo" >Tables Info</a>. Please use query No. 10. from the analysis_quries.sql for full details </li>'
-  ELSE NULL END
 FROM W;
 WITH W AS (select last_failed_time,last_archived_time,last_archived_wal from pg_archiver_stat where last_archived_time < last_failed_time)
 SELECT CASE WHEN last_archived_time IS NOT NULL
@@ -274,9 +279,10 @@ SELECT to_jsonb(r) FROM
     AND backend_type='client backend') cn) AS cn,
   (select count(*) from pg_get_class where relkind='p') as ptabs,
   (SELECT  to_jsonb(ROW(count(*) FILTER (WHERE state='active' AND state IS NOT NULL), 
-   count(*) FILTER (WHERE state='idle in transaction'), count(*) FILTER (WHERE state='idle'),
-   count(*) FILTER (WHERE state IS NULL), count(*) FILTER (WHERE leader_pid IS NOT NULL) , count(*)))
-   FROM pg_get_activity) as sess,
+  count(*) FILTER (WHERE state='idle in transaction'), count(*) FILTER (WHERE state='idle'),
+  count(*) FILTER (WHERE state IS NULL), count(*) FILTER (WHERE leader_pid IS NOT NULL) ,
+  count(*),   count(distinct backend_type)))
+  FROM pg_get_activity) as sess,
   (WITH curdb AS (SELECT trim(both '\"' from substring(connstr from '\"\w*\"')) "curdb" FROM pg_srvr WHERE connstr like '%to database%'),
     cts AS (SELECT COALESCE((SELECT COALESCE(collect_ts,(SELECT max(state_change) FROM pg_get_activity)) FROM pg_gather),current_timestamp) AS c_ts)
     SELECT to_jsonb(ROW(curdb,stats_reset,c_ts,days)) FROM 
@@ -305,7 +311,7 @@ SELECT to_jsonb(r) FROM
 \echo <footer>End of <a href="https://github.com/jobinau/pg_gather">pgGather</a> Report</footer>
 \echo <script type="text/javascript">
 \echo obj={};
-\echo meta={pgvers:["11.19","12.14","13.10","14.7","15.2"]};
+\echo meta={pgvers:["11.20","12.15","13.11","14.8","15.3"],commonExtn:["plpgsql","pg_stat_statements"],riskyExtn:["citus","tds_fdw"]};
 \echo mgrver="";
 \echo walcomprz="";
 \echo autovacuum_freeze_max_age = 0;
@@ -329,6 +335,7 @@ SELECT to_jsonb(r) FROM
 \echo checkpars();
 \echo checktabs();
 \echo checkdbs();
+\echo checkextn();
 \echo checksess();
 \echo checkfindings();
 \echo });
@@ -338,23 +345,29 @@ SELECT to_jsonb(r) FROM
 \echo   document.getElementById("busy").style="display:none";
 \echo };
 \echo function checkfindings(){
-\echo   let strfind = "";
-\echo   if (obj.cn.f1 > 0){
-\echo     strfind="<li><b>" + obj.cn.f2 + " / " + obj.cn.f1 + " connections </b> in use are new. "
+\echo  let strfind = "";
+\echo  if (obj.sess.f7 < 4){ 
+\echo   strfind += "<li><b>The pg_gather data is collected by a user who don't have proper access / privilege</b> Please run the script as a privileged user (superuser, rds_superuser etc.) or some account with pg_monitor privilege.</li>"
+\echo   document.getElementById("tableConten").title="Waitevents data will be growsly incorrect because the pg_gather data is collected by a user who don't have proper access / privilege. Please refer the Findings section";
+\echo   document.getElementById("tableConten").caption.innerHTML += "<br/>" + document.getElementById("tableConten").title
+\echo   document.getElementById("tableConten").classList.add("high");
+\echo  }
+\echo  if (obj.cn.f1 > 0){
+\echo     strfind +="<li><b>" + obj.cn.f2 + " / " + obj.cn.f1 + " connections </b> in use are new. "
 \echo     if (obj.cn.f2 > 9 || obj.cn.f2/obj.cn.f1 > 0.7 ){
 \echo       strfind+="Please consider this for improving connection pooling"
 \echo     } 
 \echo     strfind += "</li>";
-\echo   }
-\echo   if (obj.ptabs > 0) strfind += "<li>"+ obj.ptabs +" Natively partitioned tables found. Tables section could contain partitions</li>";
+\echo  }
+\echo  if (obj.ptabs > 0) strfind += "<li>"+ obj.ptabs +" Natively partitioned tables found. Tables section could contain partitions</li>";
 \echo  if(obj.clsr){
 \echo   strfind += "<li>PostgreSQL is in Standby mode or in Recovery</li>";
 \echo  }else{
 \echo   if ( obj.tabs.f2 > 0 ) strfind += "<li> <b>No vaccum info for " + obj.tabs.f2 + "</b> tables </li>";
 \echo   if ( obj.tabs.f3 > 0 ) strfind += "<li> <b>No statistics available for " + obj.tabs.f3 + " tables</b>, query planning can go wrong </li>";
-\echo   if ( obj.tabs.f1 > 10000) strfind += "<li> There are <b>" + obj.tabs.f1 + " tables</b> in the database. Only 10000 will be displayed in the report. Avoid too many tables in single database</li>";
+\echo   if ( obj.tabs.f1 > 10000) strfind += "<li> There are <b>" + obj.tabs.f1 + " tables</b> in the database. Only the biggest 10000 will be displayed in the report. Avoid too many tables in single database. You may use backend query (Query No.10) from analysis_queries.sql</li>";
 \echo   if (obj.arcfail) strfind += "<li>WAL archiving is suspected to be <b>failing</b>, please check PG logs</li>";
-\echo   if (obj.crash) strfind += "<li><b>Crash detected around "+ obj.crash +"</b>, please check PG logs</li>";
+\echo   if (obj.crash) strfind += "<li><b>Possible crash around "+ obj.crash +"</b>, please verify PG logs</li>";
 \echo   if (obj.wmemuse !== null && obj.wmemuse.length > 0){ strfind += "<li> Biggest <code>maintenance_work_mem</code> consumers are :<b>"; obj.wmemuse.forEach(function(t,idx){ strfind += (idx+1)+". "+t.f1 + " (" + bytesToSize(t.f2) + ")    " }); strfind += "</b></li>"; }
 \echo   if (obj.victims !== null && obj.victims.length > 0) strfind += "<li>There are <b>" + obj.victims.length + " sessions blocked.</b></li>"
 \echo   if (obj.sumry !== null){ strfind += "<li>Data collection took <b>" + obj.sumry.f1 + " seconds. </b>";
@@ -376,8 +389,8 @@ SELECT to_jsonb(r) FROM
 \echo   dbs.appendChild(el);
 \echo   el=document.createElement("tfoot");
 \echo   el.innerHTML = "<th colspan='3'>Active: "+ obj.sess.f1 +", Idle-in-transaction: " + obj.sess.f2 + ", Idle: " + obj.sess.f3 + ", Background: " + obj.sess.f4 + ", Workers: " + obj.sess.f5 + ", Total: " + obj.sess.f6 + "</th>";
-\echo   tblss=document.getElementById("tblss");
-\echo   tblss.appendChild(el);
+\echo   tblcs=document.getElementById("tblcs");
+\echo   tblcs.appendChild(el);
 \echo }
 \echo document.getElementById("cpus").addEventListener("change", (event) => {
 \echo   totCPU = event.target.value;
@@ -465,16 +478,17 @@ SELECT to_jsonb(r) FROM
 \echo         if(val.innerText > 1.2) val.classList.add("warn");
 \echo         break;
 \echo       case "server_version":
-\echo         val.classList.add("lime"); let setval = val.innerText.split(" ")[0]; mgrver=setval.split(".")[0];
+\echo          let setval = val.innerText.split(" ")[0]; mgrver=setval.split(".")[0];
 \echo         if ( mgrver < Math.trunc(meta.pgvers[0])){
 \echo           val.classList.add("warn"); val.title="PostgreSQL Version is outdated (EOL) and not supported";
 \echo         } else {
 \echo           meta.pgvers.forEach(function(t){
 \echo             if (Math.trunc(setval) == Math.trunc(t)){
-\echo                if (t.split(".")[1] - setval.split(".")[1] > 0 ) { val.classList.add("warn"); val.title= t.split(".")[1] - setval.split(".")[1] + " minor version updates pending. Urgent!"; }
+\echo                if (t.split(".")[1] - setval.split(".")[1] > 0 ) { val.classList.add("warn"); val.title= t.split(".")[1] - setval.split(".")[1] + " minor version updates pending. Please upgrade ASAP"; }
 \echo             }
 \echo           })  
 \echo         }
+\echo         if(val.classList.length < 1) val.classList.add("lime");
 \echo         break;
 \echo       case "synchronous_standby_names":
 \echo         if (val.innerText.trim().length > 0){ val.classList.add("warn"); val.title="Synchronous Standby can cause session hangs, and poor performance"; }
@@ -484,8 +498,9 @@ SELECT to_jsonb(r) FROM
 \echo         walcomprz = val.innerText;
 \echo         break;
 \echo       case "work_mem":
-\echo         val.classList.add("lime"); val.title=bytesToSize(val.innerText*1024,1024);
+\echo         val.title=bytesToSize(val.innerText*1024,1024) + ", Avoid global settings above 32MB to avoid memory related issues";
 \echo         if(val.innerText > 98304) val.classList.add("warn");
+\echo         else val.classList.add("lime");
 \echo         break;
 \echo     }
 \echo   }
@@ -524,15 +539,31 @@ SELECT to_jsonb(r) FROM
 \echo function checkdbs(){
 \echo   const trs=document.getElementById("dbs").rows
 \echo   const len=trs.length;
+\echo   let aborts=[];
 \echo   trs[0].cells[6].title="Average Temp generation Per Day"; trs[0].cells[7].title="Average Temp generation Per Day"; trs[0].cells[9].title="autovacuum_freeze_max_age=" + autovacuum_freeze_max_age.toLocaleString("en-US");
 \echo   for(var i=1;i<len;i++){
 \echo     tr=trs[i];
 \echo     if(obj.dbts !== null && tr.cells[0].innerHTML == obj.dbts.f1) tr.cells[0].classList.add("lime");
-\echo     [7,8].forEach(function(num) {  if (tr.cells[num].innerText > 1048576) { tr.cells[num].classList.add("lime"); tr.cells[num].title=bytesToSize(tr.cells[num].innerText) } });
-\echo     if(tr.cells[7].innerHTML > 50000000000) tr.cells[7].classList.add("warn");
+\echo     if(tr.cells[3].innerHTML > 4000){ tr.cells[3].classList.add("warn"); tr.cells[3].title = "High number of transaction aborts/rollbacks. Please inspect PostgreSQL logs"; 
+\echo      aborts.push(tr.cells[0].innerHTML)
+\echo      }
+\echo     [7,8].forEach(function(num) {  if (tr.cells[num].innerText > 1048576) { if(tr.cells[num].classList.length < 1) tr.cells[num].classList.add("lime"); tr.cells[num].title=bytesToSize(tr.cells[num].innerText) } });
+\echo     if(tr.cells[7].innerHTML > 50000000000) {  tr.cells[7].classList.remove("lime"); tr.cells[7].classList.add("warn"); tr.cells[7].title += ", High temporary file generation per day. It can cause I/O performance issues" }
 \echo     totdb=totdb+Number(tr.cells[8].innerText);
 \echo     aged(tr.cells[9]);
-\echo   }  
+\echo   }
+\echo   if (aborts.length >0)
+\echo     document.getElementById("finditem").innerHTML += "<li>High number of trasaction aborts/rollbacks in databases : <b>" + aborts.toString() + "</b>, please inspect PostgreSQL logs for more details</li>" ; 
+\echo }
+\echo function checkextn(){
+\echo   const trs=document.getElementById("tblextn").rows
+\echo   const len=trs.length;
+\echo   let riskyExtn=[];
+\echo   for(var i=1;i<len;i++){
+\echo     tr=trs[i];
+\echo     if (meta.riskyExtn.includes(tr.cells[1].innerHTML)){ tr.cells[1].classList.add("warn"); tr.cells[1].title = "Risky to use in mission critical systems without support aggrement. Crashes are reported" ; }
+\echo     else if (!meta.commonExtn.includes(tr.cells[1].innerHTML)) tr.cells[1].classList.add("lime");
+\echo   }
 \echo }
 \echo const getCellValue = (tr, idx) => tr.children[idx].innerText || tr.children[idx].textContent;
 \echo const comparer = (idx, asc) => (a, b) => ((v1, v2) =>   v1 !== '''''' && v2 !== '''''' && !isNaN(v1) && !isNaN(v2) ? v1 - v2 : v1.toString().localeCompare(v2))(getCellValue(asc ? a : b, idx), getCellValue(asc ? b : a, idx));
@@ -575,6 +606,14 @@ SELECT to_jsonb(r) FROM
 \echo   }
 \echo   return "<b>" + th.cells[0].innerText + "</b><br/>Schema : " + ns.nsname + str;
 \echo }
+\echo function sessdtls(th){
+\echo   let o=JSON.parse(th.cells[1].innerText); let str="";
+\echo   if (o.f1 !== null) str += "Database :" + o.f1 + "<br/>";
+\echo   if (o.f2 !== null && o.f2.length > 1 ) str += "Application :" + o.f2 + "<br/>";
+\echo   if (o.f3 !== null) str += "Client Host :" + o.f3 + "<br/>";
+\echo   if (str.length < 1) str+="Independent/Background process";
+\echo   return str;
+\echo }
 \echo document.querySelectorAll(".thidden tr td:first-child").forEach(td => td.addEventListener("mouseover", (() => {
 \echo   th=td.parentNode;
 \echo   tab=th.closest("table");
@@ -583,12 +622,13 @@ SELECT to_jsonb(r) FROM
 \echo   el.setAttribute("align","left");
 \echo   if(tab.id=="dbs") el.innerHTML=dbsdtls(th);
 \echo   if(tab.id=="tabInfo") el.innerHTML=tabdtls(th);
+\echo   if(tab.id=="tblsess") el.innerHTML=sessdtls(th);
 \echo   th.cells[2].appendChild(el);
 \echo })));
 \echo document.querySelectorAll(".thidden tr td:first-child").forEach(td => td.addEventListener("mouseout", (() => {
 \echo   td.parentNode.cells[2].innerHTML=td.parentNode.cells[2].firstChild.textContent;
 \echo })));
-\echo document.querySelectorAll("#tblsess tr td:nth-child(5)").forEach(td => td.addEventListener("dblclick", (() => {
+\echo document.querySelectorAll("#tblsess tr td:nth-child(6)").forEach(td => td.addEventListener("dblclick", (() => {
 \echo   if (td.title){
 \echo   console.log(td.title);
 \echo   navigator.clipboard.writeText(td.title).then(() => {  
@@ -620,7 +660,7 @@ SELECT to_jsonb(r) FROM
 \echo function checksess(){
 \echo trs=document.getElementById("tblsess").rows;
 \echo for (let tr of trs){
-\echo  pid=tr.cells[0]; sql=tr.cells[4]; xidage=tr.cells[7]; stime=tr.cells[9];
+\echo  pid=tr.cells[0]; sql=tr.cells[5]; xidage=tr.cells[8]; stime=tr.cells[10];
 \echo  if(xidage.innerText > 20) xidage.classList.add("warn");
 \echo  if (blokers.indexOf(Number(pid.innerText)) > -1){ pid.classList.add("high"); pid.title="Blocker"; };
 \echo  if (blkvictims.indexOf(Number(pid.innerText)) > -1) { pid.classList.add("warn"); pid.title="Victim of blocker : " + obj.victims.find(el => el.f1 == pid.innerText).f2.toString(); };
@@ -658,6 +698,11 @@ SELECT to_jsonb(r) FROM
 \echo       }
 \echo     }
 \echo   }
+\echo   if (tr.cells[16].innerText.trim() == "" ){
+\echo     tr.cells[16].classList.add("high"); tr.cells[16].title="bgwriter stats are not available";
+\echo     document.getElementById("tblchkpnt").classList.add("high");
+\echo     document.getElementById("tblchkpnt").title = "The bgwriter stats are not yet available. This could happen if data is collected immediately after the stats reset";
+\echo   }
 \echo }
 \echo tab=document.getElementById("tblreplstat")
 \echo if (tab.rows.length > 1){
@@ -671,6 +716,11 @@ SELECT to_jsonb(r) FROM
 \echo      }
 \echo     });
 \echo     [14,15].forEach(function(num){  if(row.cells[num].innerText > 20) row.cells[num].classList.add("warn"); });
+\echo     if (row.cells[13].innerText == "f" || row.cells[2].innerText == "") {
+\echo       row.cells[8].classList.add("high");
+\echo       row.cells[8].title="Abandoned replication slot";
+\echo       document.getElementById("finditem").innerHTML += "<li> Abandoned replication slot : <b>" +  row.cells[8].innerText + "</b> found. This can cause unwanted WAL retention" ;
+\echo     }
 \echo   }
 \echo }else{
 \echo   tab.remove()

--- a/postgresql/pg_gather/gather_schema.sql
+++ b/postgresql/pg_gather/gather_schema.sql
@@ -170,6 +170,7 @@ CREATE UNLOGGED TABLE pg_get_index (
     indrelid oid,
     indisunique boolean,
     indisprimary boolean,
+    indisvalid boolean,
     numscans bigint,
     size bigint
 );


### PR DESCRIPTION
* Verification of data collection
   1. Report if bgwriter stats are less than 1 day old. because analysis won't be effective for a short duration of statistics
   2. Version of `gather.sql` is used for data collection. Report the usage of the old script. Older versions may have known bugs/limitations.
   3. Whether the data is collected from a standby. And analyse based on that info.
* Report the number of aborted transactions per day per database.
  Fix: findings section to is used for reporting high aborts only if there is at least a database in the list with a high number of aborts
* Capture `indisvalid` flag for further analysis of indexes
* PostgreSQL extensions are checked to see whether they are recommended ones or rarely used ones or ones which is reported to have freequent issues.
* Non-critical but important items in the reports are highlighted with different backgrounds.
* javascript improvements to avoid multiple CSS display classes are set to the same element
* Documentation updates for wait events.
* If bgwriter stats are not available, mention the same in the report
* Address Issue 37, division by zero if data from pg_stat_bgwriter is not available
* Now Collects Partition information from pg_inherits