### PR TITLE
heading for warning against users copy-pasting the output

### DIFF
--- a/postgresql/pg_gather/gather.sql
+++ b/postgresql/pg_gather/gather.sql
@@ -1,6 +1,7 @@
 ---- pg_gather : Gather Performance Metics and PostgreSQL Configuration
 ---- For Revision History : https://github.com/jobinau/pg_gather/releases
--- pg_gather version
+\echo '--**** IMPORTANT !!: PLEASE DONT COPY-PASTE THE OUTPUT. TEXT EDITORS CAN DESTROY THE TSV FORMATTING AND THE OUTPUT MAY NOT BE USEFUL THERE AFTER ****--'
+\echo '\\r'
 \set ver 23
 \echo '\\set ver ':ver
 --Detect PG versions and type of gathering


### PR DESCRIPTION
heading for warning against users copy-pasting the output as customers are frequently making that mistake. Additionally, adding protection against junks at the beginning of file, which happens in the case of the operator
This is an emergency fix.