### PR TITLE
jinyou - add script measure_query_cache_sql.sh

### DIFF
--- a/mysql/proxysql/measure_query_cache_sql.sh
+++ b/mysql/proxysql/measure_query_cache_sql.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+# - Capture slow query log / audit log for some time (5 - 30 minutes)
+# - Using pt-query-digest --sample <N> --no-report;  to extract samples of each type of queries;
+# - Split the output in one query per file (.sql file must contain appropriate USE <db>;  filaname should be pt-query-digest fingerprint + sequence # + .sql)
+# Then on a replica:
+
+INTERVAL=1; # how often to check results
+ITERATIONS=10; # how many consecutive checks to perform
+CYCLES=5; # how many consecutive identical hashes to consider as candidate
+          # For example, if the sql gets the same result for more than 5 times, the sql will be in the QUERIES_CANDIDATES_FOLDER
+
+# Configure mysql user and password
+MYSQL="mysql "
+
+QUERIES_FOLDER="${HOME}/queries_for_caching_evaluation/pending";
+QUERIES_DONE_FOLDER="${HOME}/queries_for_caching_evaluation/done";
+QUERIES_CANDIDATES_FOLDER="${HOME}/queries_for_caching_evaluation/candidates";
+
+for query_file in "${QUERIES_FOLDER}"/*.sql ; do {
+    query_file=$(basename "${query_file}")
+    cycle=0;
+    iteration=0;
+    while [[ ${iteration} -lt ${ITERATIONS} ]]; do {
+        checksum=$(${MYSQL} --quick < "${QUERIES_FOLDER}/${query_file}" | md5sum | awk '{print $1}');
+        if [[ -n "${last_checksum}" ]]; then {
+            if [[ "${last_checksum}" == "${checksum}" ]]; then {
+                cycle=$((cycle+1));
+            } else {
+                cycle=0;
+            } fi;
+        } fi;
+
+        if [[ ${cycle} -ge ${CYCLES} ]]; then {
+            break;
+        } fi;
+
+        last_checksum="${checksum}";
+        iteration=$((iteration+1));
+        sleep ${INTERVAL};
+    } done;
+    mv -v "${QUERIES_FOLDER}/${query_file}" "${QUERIES_DONE_FOLDER}/${query_file}";
+    if [[ ${cycle} -ge ${CYCLES} ]]; then {
+        ln -vs "${QUERIES_DONE_FOLDER}/${query_file}" "${QUERIES_CANDIDATES_FOLDER}/${query_file}";
+    } fi;
+
+} done;


### PR DESCRIPTION
The script will measure SQL files in the `QUERIES_FOLDER`

If the SQL gets the same result more than 5 times, the SQL will be in the `QUERIES_CANDIDATES_FOLDER`.

# test
## before run
The script will check all files with the prefix `sql` in the `QUERIES_FOLDER` : `(${HOME}/queries_for_caching_evaluation/pending)`
For example, there are 3 files
```
queries_for_caching_evaluation
├── candidates
├── done
└── pending
    ├── distinct1.sql
    ├── distinct2.sql
    └── select_now.sql
```
The distinct1.sql and distinct2.sql will get the same result, but the select_now.sql does not.

```
tail -n 10 queries_for_caching_evaluation/pending/*.sql
==> queries_for_caching_evaluation/pending/distinct1.sql <==
use test;
select count(distinct c) as data from sbtest1;

==> queries_for_caching_evaluation/pending/distinct2.sql <==
use test;
select count(distinct c) as data from sbtest1;

==> queries_for_caching_evaluation/pending/select_now.sql <==
use test;
select now();
```
## Running the script
```
bash measure_query_cache_sql.sh
mysql: [Warning] Using a password on the command line interface can be insecure.
mysql: [Warning] Using a password on the command line interface can be insecure.
mysql: [Warning] Using a password on the command line interface can be insecure.
mysql: [Warning] Using a password on the command line interface can be insecure.
mysql: [Warning] Using a password on the command line interface can be insecure.
mysql: [Warning] Using a password on the command line interface can be insecure.
renamed '/home/ubuntu/queries_for_caching_evaluation/pending/distinct1.sql' -> '/home/ubuntu/queries_for_caching_evaluation/done/distinct1.sql'
'/home/ubuntu/queries_for_caching_evaluation/candidates/distinct1.sql' -> '/home/ubuntu/queries_for_caching_evaluation/done/distinct1.sql'
mysql: [Warning] Using a password on the command line interface can be insecure.
mysql: [Warning] Using a password on the command line interface can be insecure.
mysql: [Warning] Using a password on the command line interface can be insecure.
mysql: [Warning] Using a password on the command line interface can be insecure.
mysql: [Warning] Using a password on the command line interface can be insecure.
renamed '/home/ubuntu/queries_for_caching_evaluation/pending/distinct2.sql' -> '/home/ubuntu/queries_for_caching_evaluation/done/distinct2.sql'
'/home/ubuntu/queries_for_caching_evaluation/candidates/distinct2.sql' -> '/home/ubuntu/queries_for_caching_evaluation/done/distinct2.sql'
mysql: [Warning] Using a password on the command line interface can be insecure.
mysql: [Warning] Using a password on the command line interface can be insecure.
mysql: [Warning] Using a password on the command line interface can be insecure.
mysql: [Warning] Using a password on the command line interface can be insecure.
mysql: [Warning] Using a password on the command line interface can be insecure.
mysql: [Warning] Using a password on the command line interface can be insecure.
mysql: [Warning] Using a password on the command line interface can be insecure.
mysql: [Warning] Using a password on the command line interface can be insecure.
mysql: [Warning] Using a password on the command line interface can be insecure.
mysql: [Warning] Using a password on the command line interface can be insecure.
renamed '/home/ubuntu/queries_for_caching_evaluation/pending/select_now.sql' -> '/home/ubuntu/queries_for_caching_evaluation/done/select_now.sql'
```
## after run
All files are located in the `QUERIES_DONE_FOLDER`. Only the distinct1.sql and distinct2.sql are in the `QUERIES_CANDIDATES_FOLDER`.

```
queries_for_caching_evaluation
├── candidates
│   ├── distinct1.sql -> /home/ubuntu/queries_for_caching_evaluation/done/distinct1.sql
│   └── distinct2.sql -> /home/ubuntu/queries_for_caching_evaluation/done/distinct2.sql
├── done
│   ├── distinct1.sql
│   ├── distinct2.sql
│   └── select_now.sql
└── pending

3 directories, 5 files
```

