### PR TITLE
removing orphaned tables from the InnoDB table dictionary

### DIFF
--- a/mysql/remove_invalid_table_from_data_dict/README.md
+++ b/mysql/remove_invalid_table_from_data_dict/README.md
@@ -1,0 +1,75 @@
+# Description
+This is a patch for removing orphaned tables from the InnoDB table dictionary.
+
+# How to use it
+
+- patch MySQL 5.7.26
+```
+mkdir build
+mkdir boost
+wget https://codeload.github.com/mysql/mysql-server/zip/refs/tags/mysql-5.7.26
+unzip mysql-5.7.26
+cd mysql-server-mysql-5.7.26
+git apply ${the path of the repo}/remove_invalid_table_from_data_dict.patch
+```
+- compile
+```
+cmake -B ../build -DDOWNLOAD_BOOST=1 -DWITH_BOOST=../boost
+cd ../build
+make -j 8
+```
+
+- start the self-compiled mysqld
+```
+mysqladmin shutdown
+./sql/mysqld --defaults-file=${the configuration file}
+```
+
+- start the normal mysqld
+```
+mysqladmin shutdown
+systemctl start mysql
+```
+
+# test
+
+## Before the patch
+> there is one orphaned data file in my test instance.
+
+```
+mysql [localhost:5741] {msandbox} ((none)) > SELECT * FROM INFORMATION_SCHEMA.INNODB_SYS_TABLES WHERE NAME LIKE '%#sql%';
++----------+--------------------+------+--------+-------+-------------+------------+---------------+------------+
+| TABLE_ID | NAME               | FLAG | N_COLS | SPACE | FILE_FORMAT | ROW_FORMAT | ZIP_PAGE_SIZE | SPACE_TYPE |
++----------+--------------------+------+--------+-------+-------------+------------+---------------+------------+
+|       64 | tmp/#sql3c316e_2_0 |    1 |      4 |    46 | Antelope    | Compact    |             0 | Single     |
++----------+--------------------+------+--------+-------+-------------+------------+---------------+------------+
+1 row in set (0.00 sec)
+
+mysql [localhost:5741] {msandbox} ((none)) > select * from information_schema.innodb_sys_datafiles where path like '%#sql%';
++-------+-------------------------------------------------------------+
+| SPACE | PATH                                                        |
++-------+-------------------------------------------------------------+
+|    46 | /home/jinyou.ma/sandboxes/msb_5_6_43/tmp/#sql3c316e_2_0.ibd |
++-------+-------------------------------------------------------------+
+1 row in set (0.00 sec)
+```
+
+## After the patch
+
+> There is a message about removing the missing table in the mysql error log.
+```
+2024-01-24T03:29:47.553930Z 0 [ERROR] InnoDB: Could not find a valid tablespace file for `tmp/#sql3c316e_2_0`. Please refer to http://dev.mysql.com/doc/refman/5.7/en/innodb-troubleshooting-datadict.html for how to resolve the issue.
+2024-01-24T03:29:47.553938Z 0 [Warning] InnoDB: Ignoring tablespace `tmp/#sql3c316e_2_0` because it could not be opened.
+2024-01-24T03:29:47.553944Z 0 [Warning] InnoDB: Removing missing table `tmp/#sql3c316e_2_0` from InnoDB data dictionary.
+```
+
+> The mysql does not contain orphaned data file
+
+```
+mysql [localhost:5741] {msandbox} ((none)) > SELECT * FROM INFORMATION_SCHEMA.INNODB_SYS_TABLES WHERE NAME LIKE '%#sql%';
+Empty set (0.00 sec)
+
+mysql [localhost:5741] {msandbox} ((none)) > select * from information_schema.innodb_sys_datafiles where path like '%#sql%';
+Empty set (0.00 sec)
+```
+

--- a/mysql/remove_invalid_table_from_data_dict/remove_invalid_table_from_data_dict.patch
+++ b/mysql/remove_invalid_table_from_data_dict/remove_invalid_table_from_data_dict.patch
@@ -1,0 +1,157 @@
+diff --git a/storage/innobase/dict/dict0load.cc b/storage/innobase/dict/dict0load.cc
+index 96a30a7ed4f..acbcae4dfad 100644
+--- a/storage/innobase/dict/dict0load.cc
++++ b/storage/innobase/dict/dict0load.cc
+@@ -1322,6 +1322,134 @@ dict_sys_tables_rec_read(
+ 	return(true);
+ }
+ 
++static
++void
++remove_invalid_table_from_data_dict(const char *name)
++{
++	trx_t*		trx;
++	pars_info_t*	info = NULL;
++
++	ut_ad(rw_lock_own(dict_operation_lock, RW_LOCK_X));
++	ut_ad(mutex_own(&dict_sys->mutex));
++
++	trx = trx_allocate_for_background();
++	trx->dict_operation_lock_mode = RW_X_LATCH;
++	trx_start_for_ddl(trx, TRX_DICT_OP_TABLE);
++
++	ut_ad(mutex_own(&dict_sys->mutex));
++
++	trx->op_info = "removing invalid table from data dictionary";
++
++	if (dict_table_get_low("SYS_DATAFILES") != NULL) {
++		info = pars_info_create();
++
++		pars_info_add_str_literal(info, "table_name", name);
++
++		que_eval_sql(info,
++			     "PROCEDURE DROP_TABLESPACE_PROC () IS\n"
++			     "space_id INT;\n"
++
++			     "BEGIN\n"
++			     "SELECT SPACE INTO space_id\n"
++			     "FROM SYS_TABLES\n"
++			     "WHERE NAME = :table_name;\n"
++			     "IF (SQL % NOTFOUND) THEN\n"
++			     "       RETURN;\n"
++			     "END IF;\n"
++			     "DELETE FROM SYS_TABLESPACES\n"
++			     "WHERE SPACE = space_id;\n"
++			     "DELETE FROM SYS_DATAFILES\n"
++			     "WHERE SPACE = space_id;\n"
++			     "END;\n"
++			     , FALSE, trx);
++	}
++
++	info = pars_info_create();
++
++	pars_info_add_str_literal(info, "table_name", name);
++
++	que_eval_sql(info,
++		     "PROCEDURE DROP_TABLE_PROC () IS\n"
++		     "sys_foreign_id CHAR;\n"
++		     "table_id CHAR;\n"
++		     "index_id CHAR;\n"
++		     "foreign_id CHAR;\n"
++		     "found INT;\n"
++
++		     "DECLARE CURSOR cur_fk IS\n"
++		     "SELECT ID FROM SYS_FOREIGN\n"
++		     "WHERE FOR_NAME = :table_name\n"
++		     "AND TO_BINARY(FOR_NAME)\n"
++		     "  = TO_BINARY(:table_name)\n"
++		     "LOCK IN SHARE MODE;\n"
++
++		     "DECLARE CURSOR cur_idx IS\n"
++		     "SELECT ID FROM SYS_INDEXES\n"
++		     "WHERE TABLE_ID = table_id\n"
++		     "LOCK IN SHARE MODE;\n"
++
++		     "BEGIN\n"
++		     "SELECT ID INTO table_id\n"
++		     "FROM SYS_TABLES\n"
++		     "WHERE NAME = :table_name\n"
++		     "LOCK IN SHARE MODE;\n"
++		     "IF (SQL % NOTFOUND) THEN\n"
++		     "       RETURN;\n"
++		     "END IF;\n"
++		     "found := 1;\n"
++		     "SELECT ID INTO sys_foreign_id\n"
++		     "FROM SYS_TABLES\n"
++		     "WHERE NAME = 'SYS_FOREIGN'\n"
++		     "LOCK IN SHARE MODE;\n"
++		     "IF (SQL % NOTFOUND) THEN\n"
++		     "       found := 0;\n"
++		     "END IF;\n"
++		     "IF (:table_name = 'SYS_FOREIGN') THEN\n"
++		     "       found := 0;\n"
++		     "END IF;\n"
++		     "IF (:table_name = 'SYS_FOREIGN_COLS') THEN\n"
++		     "       found := 0;\n"
++		     "END IF;\n"
++		     "OPEN cur_fk;\n"
++		     "WHILE found = 1 LOOP\n"
++		     "       FETCH cur_fk INTO foreign_id;\n"
++		     "       IF (SQL % NOTFOUND) THEN\n"
++		     "               found := 0;\n"
++		     "       ELSE\n"
++		     "               DELETE FROM SYS_FOREIGN_COLS\n"
++		     "               WHERE ID = foreign_id;\n"
++		     "               DELETE FROM SYS_FOREIGN\n"
++		     "               WHERE ID = foreign_id;\n"
++		     "       END IF;\n"
++		     "END LOOP;\n"
++		     "CLOSE cur_fk;\n"
++		     "found := 1;\n"
++		     "OPEN cur_idx;\n"
++		     "WHILE found = 1 LOOP\n"
++		     "       FETCH cur_idx INTO index_id;\n"
++		     "       IF (SQL % NOTFOUND) THEN\n"
++		     "               found := 0;\n"
++		     "       ELSE\n"
++		     "               DELETE FROM SYS_FIELDS\n"
++		     "               WHERE INDEX_ID = index_id;\n"
++		     "               DELETE FROM SYS_INDEXES\n"
++		     "               WHERE ID = index_id\n"
++		     "               AND TABLE_ID = table_id;\n"
++		     "       END IF;\n"
++		     "END LOOP;\n"
++		     "CLOSE cur_idx;\n"
++		     "DELETE FROM SYS_COLUMNS\n"
++		     "WHERE TABLE_ID = table_id;\n"
++		     "DELETE FROM SYS_TABLES\n"
++		     "WHERE NAME = :table_name;\n"
++		     "END;\n"
++		     , FALSE, trx);
++
++	trx_commit_for_mysql(trx);
++	trx->dict_operation_lock_mode = 0;
++	trx_free_for_background(trx);
++}
++
+ /** Load and check each non-predefined tablespace mentioned in SYS_TABLES.
+ Search SYS_TABLES and check each tablespace mentioned that has not
+ already been added to the fil_system.  If it is valid, add it to the
+@@ -1470,6 +1598,17 @@ dict_check_sys_tables(
+ 				<< " because it could not be opened.";
+ 		}
+ 
++		if (err != DB_SUCCESS && !srv_read_only_mode ) {
++			if (8 <= strlen(space_name) && ( strncmp("tmp/#sql",space_name,8) == 0 )) {
++
++				mtr_commit(&mtr);
++				ib::warn() << "Removing missing table `"
++					<< space_name
++					<< "` from InnoDB data dictionary.";
++				remove_invalid_table_from_data_dict(space_name);
++				mtr_start(&mtr);
++			}
++		}
+ 		max_space_id = ut_max(max_space_id, space_id);
+ 
+ 		ut_free(table_name.m_name);


### PR DESCRIPTION
# Description
This is a patch for removing orphaned tables from the InnoDB table dictionary.

# How to use it

- patch MySQL 5.7.26
```
mkdir build
mkdir boost
wget https://codeload.github.com/mysql/mysql-server/zip/refs/tags/mysql-5.7.26
unzip mysql-5.7.26
cd mysql-server-mysql-5.7.26
git apply ${the path of the repo}/remove_invalid_table_from_data_dict.patch
```
- compile
```
cmake -B ../build -DDOWNLOAD_BOOST=1 -DWITH_BOOST=../boost
cd ../build
make -j 8
```

- start the self-compiled mysqld
```
mysqladmin shutdown
./sql/mysqld --defaults-file=${the configuration file}
```

- start the normal mysqld
```
mysqladmin shutdown
systemctl start mysql
```

# test

## Before the patch
> there is one orphaned data file in my test instance.

```
mysql [localhost:5741] {msandbox} ((none)) > SELECT * FROM INFORMATION_SCHEMA.INNODB_SYS_TABLES WHERE NAME LIKE '%#sql%';
+----------+--------------------+------+--------+-------+-------------+------------+---------------+------------+
| TABLE_ID | NAME               | FLAG | N_COLS | SPACE | FILE_FORMAT | ROW_FORMAT | ZIP_PAGE_SIZE | SPACE_TYPE |
+----------+--------------------+------+--------+-------+-------------+------------+---------------+------------+
|       64 | tmp/#sql3c316e_2_0 |    1 |      4 |    46 | Antelope    | Compact    |             0 | Single     |
+----------+--------------------+------+--------+-------+-------------+------------+---------------+------------+
1 row in set (0.00 sec)

mysql [localhost:5741] {msandbox} ((none)) > select * from information_schema.innodb_sys_datafiles where path like '%#sql%';
+-------+-------------------------------------------------------------+
| SPACE | PATH                                                        |
+-------+-------------------------------------------------------------+
|    46 | /home/jinyou.ma/sandboxes/msb_5_6_43/tmp/#sql3c316e_2_0.ibd |
+-------+-------------------------------------------------------------+
1 row in set (0.00 sec)
```

## After the patch

> There is a message about removing the missing table in the mysql error log.
```
2024-01-24T03:29:47.553930Z 0 [ERROR] InnoDB: Could not find a valid tablespace file for `tmp/#sql3c316e_2_0`. Please refer to http://dev.mysql.com/doc/refman/5.7/en/innodb-troubleshooting-datadict.html for how to resolve the issue.
2024-01-24T03:29:47.553938Z 0 [Warning] InnoDB: Ignoring tablespace `tmp/#sql3c316e_2_0` because it could not be opened.
2024-01-24T03:29:47.553944Z 0 [Warning] InnoDB: Removing missing table `tmp/#sql3c316e_2_0` from InnoDB data dictionary.
```

> The mysql does not contain orphaned data file

```
mysql [localhost:5741] {msandbox} ((none)) > SELECT * FROM INFORMATION_SCHEMA.INNODB_SYS_TABLES WHERE NAME LIKE '%#sql%';
Empty set (0.00 sec)

mysql [localhost:5741] {msandbox} ((none)) > select * from information_schema.innodb_sys_datafiles where path like '%#sql%';
Empty set (0.00 sec)
```